### PR TITLE
Fix for duplicate encoding values not showing up in the TNT Encoding menu.

### DIFF
--- a/Components/ResultView.razor.cs
+++ b/Components/ResultView.razor.cs
@@ -451,28 +451,6 @@ public partial class ResultView
                 });
             }
 
-            // for (var i = 0; i < Data.RedTNTConfiguration.Count; i++)
-            //     redTntUsage[Data.RedTNTConfiguration[i]] = tntCombination[i];
-
-            // for (var i = 0; i < Data.BlueTNTConfiguration.Count; i++)
-            //     blueTntUsage[Data.BlueTNTConfiguration[i]] = tntCombination[i + Data.RedTNTConfiguration.Count];
-
-            // foreach (var redTnt in redTntUsage)
-            //     TntResults.Add(new TntConfigurationResult
-            //     {
-            //         TntValue = redTnt.Key,
-            //         RedIsUsed = redTnt.Value,
-            //         BlueIsUsed = blueTntUsage.ContainsKey(redTnt.Key) && blueTntUsage[redTnt.Key]
-            //     });
-
-            // foreach (var blueTnt in blueTntUsage.Where(blueTnt => !redTntUsage.ContainsKey(blueTnt.Key)))
-            //     TntResults.Add(new TntConfigurationResult
-            //     {
-            //         TntValue = blueTnt.Key,
-            //         RedIsUsed = false,
-            //         BlueIsUsed = blueTnt.Value
-            //     });
-
             RefreshPage();
         });
 

--- a/Components/ResultView.razor.cs
+++ b/Components/ResultView.razor.cs
@@ -410,7 +410,7 @@ public partial class ResultView
 
         EventManager.Instance.AddListener<BaseEventArgs>("calculateTntEncoding", async (_, _) =>
         {
-            var success = Calculation.CalculateTNTConfiguration(Data.RedTNT, Data.BlueTNT, out var tntCombination);
+            var success = Calculation.CalculateTNTConfiguration(Data.RedTNT, Data.BlueTNT, out var redTntEncoding, out var blueTntEncoding);
 
             if (!success)
             {
@@ -423,30 +423,55 @@ public partial class ResultView
 
             TntResults.Clear();
 
-            Dictionary<int, bool> redTntUsage = new();
-            Dictionary<int, bool> blueTntUsage = new();
+            foreach (int n in Data.RedTNTConfiguration) {
+                bool red = false, blue = false;
+                if (redTntEncoding.Contains(n)) {
+                    red = true;
+                    redTntEncoding.Remove(n);
+                }
+                if (blueTntEncoding.Contains(n)) {
+                    blue = true;
+                    blueTntEncoding.Remove(n);
+                }
 
-            for (var i = 0; i < Data.RedTNTConfiguration.Count; i++)
-                redTntUsage[Data.RedTNTConfiguration[i]] = tntCombination[i];
-
-            for (var i = 0; i < Data.BlueTNTConfiguration.Count; i++)
-                blueTntUsage[Data.BlueTNTConfiguration[i]] = tntCombination[i + Data.RedTNTConfiguration.Count];
-
-            foreach (var redTnt in redTntUsage)
-                TntResults.Add(new TntConfigurationResult
-                {
-                    TntValue = redTnt.Key,
-                    RedIsUsed = redTnt.Value,
-                    BlueIsUsed = blueTntUsage.ContainsKey(redTnt.Key) && blueTntUsage[redTnt.Key]
+                TntResults.Add(new TntConfigurationResult {
+                    TntValue = n, RedIsUsed = red, BlueIsUsed = blue
                 });
+            }
 
-            foreach (var blueTnt in blueTntUsage.Where(blueTnt => !redTntUsage.ContainsKey(blueTnt.Key)))
-                TntResults.Add(new TntConfigurationResult
-                {
-                    TntValue = blueTnt.Key,
-                    RedIsUsed = false,
-                    BlueIsUsed = blueTnt.Value
+            foreach (int n in Data.BlueTNTConfiguration.Where(n => !Data.RedTNTConfiguration.Contains(n))) {
+                bool blue = false;
+                if (blueTntEncoding.Contains(n)) {
+                    blue = true;
+                    blueTntEncoding.Remove(n);
+                }
+
+                TntResults.Add(new TntConfigurationResult {
+                    TntValue = n, RedIsUsed = false, BlueIsUsed = blue
                 });
+            }
+
+            // for (var i = 0; i < Data.RedTNTConfiguration.Count; i++)
+            //     redTntUsage[Data.RedTNTConfiguration[i]] = tntCombination[i];
+
+            // for (var i = 0; i < Data.BlueTNTConfiguration.Count; i++)
+            //     blueTntUsage[Data.BlueTNTConfiguration[i]] = tntCombination[i + Data.RedTNTConfiguration.Count];
+
+            // foreach (var redTnt in redTntUsage)
+            //     TntResults.Add(new TntConfigurationResult
+            //     {
+            //         TntValue = redTnt.Key,
+            //         RedIsUsed = redTnt.Value,
+            //         BlueIsUsed = blueTntUsage.ContainsKey(redTnt.Key) && blueTntUsage[redTnt.Key]
+            //     });
+
+            // foreach (var blueTnt in blueTntUsage.Where(blueTnt => !redTntUsage.ContainsKey(blueTnt.Key)))
+            //     TntResults.Add(new TntConfigurationResult
+            //     {
+            //         TntValue = blueTnt.Key,
+            //         RedIsUsed = false,
+            //         BlueIsUsed = blueTnt.Value
+            //     });
 
             RefreshPage();
         });

--- a/PearlCalculatorLib/General/Calculation.cs
+++ b/PearlCalculatorLib/General/Calculation.cs
@@ -173,17 +173,16 @@ namespace PearlCalculatorLib.General
         /// <param name="blueTNT">The amount of blue TNT</param>
         /// <param name="tntCombination">Output the TNT combination</param>
         /// <returns>Returns a true or false value indicates whether the calculation is correctly executed or not</returns>
-        public static bool CalculateTNTConfiguration(int redTNT, int blueTNT, out BitArray tntCombination)
+        public static bool CalculateTNTConfiguration(int redTNT, int blueTNT, out List<int> redTntEncoding, out List<int> blueTntEncoding)
         {
-            int indexCount = Data.RedTNTConfiguration.Count + Data.BlueTNTConfiguration.Count;
-            tntCombination = new BitArray(indexCount);
+
+            redTntEncoding = new List<int>();
+            blueTntEncoding = new List<int>();
 
             //How can i sort it if i don't know anything about the configuration
             if (Data.RedTNTConfiguration.Count == 0 && Data.BlueTNTConfiguration.Count == 0)
                 return false;
 
-            BitArray redBitArray = new BitArray(indexCount);
-            BitArray blueBitArray = new BitArray(indexCount);
             List<int> sortedRedConfig = new List<int>(Data.RedTNTConfiguration);
             List<int> sortedBlueConfig = new List<int>(Data.BlueTNTConfiguration);
 
@@ -191,16 +190,16 @@ namespace PearlCalculatorLib.General
             sortedRedConfig.Sort((a, b) => a >= b ? (a == b ? 0 : -1) : 1);
             sortedBlueConfig.Sort((a, b) => a >= b ? (a == b ? 0 : -1) : 1);
 
+            
+
             for (int i = 0; i < sortedRedConfig.Count; i++)
             {
                 if (redTNT >= sortedRedConfig[i])
                 {
                     redTNT -= sortedRedConfig[i];
                     //Sets the corresponding bit to true according to the Data.RedTNTConfiguration
-                    redBitArray.Set(Data.RedTNTConfiguration.FindIndex(x => x == sortedRedConfig[i]), true);
+                    redTntEncoding.Add(sortedRedConfig[i]);
                 }
-                else
-                    redBitArray.Set(Data.RedTNTConfiguration.FindIndex(x => x == sortedRedConfig[i]), false);
             }
 
             for (int i = 0; i < sortedBlueConfig.Count; i++)
@@ -209,16 +208,9 @@ namespace PearlCalculatorLib.General
                 {
                     blueTNT -= sortedBlueConfig[i];
                     //Sets the corresponding bit to true according to the Data.BlueTNTConfiguration
-                    blueBitArray.Set(Data.BlueTNTConfiguration.FindIndex(x => x == sortedBlueConfig[i]), true);
+                    blueTntEncoding.Add(sortedBlueConfig[i]);
                 }
-                else
-                    blueBitArray.Set(Data.BlueTNTConfiguration.FindIndex(x => x == sortedBlueConfig[i]), false);
             }
-
-            //Combine those result into tntCombination
-            tntCombination.Or(redBitArray);
-            blueBitArray.LeftShift(Data.RedTNTConfiguration.Count);
-            tntCombination.Or(blueBitArray);
 
             return true;
         }


### PR DESCRIPTION
If duplicate values are put in the encoding configuration, then those duplicated will not be displayed in the encoding table. This pr fixes that.